### PR TITLE
Recursion

### DIFF
--- a/barrel/expander.rkt
+++ b/barrel/expander.rkt
@@ -30,7 +30,7 @@
 (provide main)
 
 (define-macro (word WORDS ...)
-  #'(block (dict-set! definitions (first (list WORDS ...)) (rest (list WORDS ...)))))
+  #'(dict-set! definitions (first (list WORDS ...)) (rest (list WORDS ...))))
 (provide word)
 
 (define-macro (const CONST)

--- a/barrel/expander.rkt
+++ b/barrel/expander.rkt
@@ -1,13 +1,11 @@
 #lang br/quicklang
 (require racket/dict)
 (require racket/block)
-(require threading)
 (require "core.rkt")
-(require "util.rkt")
 (provide (all-from-out "core.rkt"))
 
-;(define definitions (make-hash))
-;(provide definitions)
+(define definitions (make-hash))
+(provide definitions)
 
 (define-macro (barrel-module-begin PARSE-TREE) 
   #'(#%module-begin
@@ -31,9 +29,8 @@
       (void (apply-stack stack (rest (list WORDS ...))))))
 (provide main)
 
-(define-macro (word NAME WORDS ...)
-  ;#'(dict-set! definitions (first (list WORDS ...)) (rest (list WORDS ...)))
-  #'(string-define NAME (list (WORDS ...))))
+(define-macro (word WORDS ...)
+  #'(dict-set! definitions (first (list WORDS ...)) (rest (list WORDS ...))))
 (provide word)
 
 (define-macro (const CONST)
@@ -63,6 +60,5 @@
                               (lambda (e) (begin
                                             (displayln (format "unknown id: ~a" ID))
                                             (error 'unknown-id)))])
-                ;((curry apply-word) (dict-ref definitions ID)))])
-               ((curry apply-word) ID))])
+                ((curry apply-word) (dict-ref definitions ID)))])
 (provide id)

--- a/barrel/expander.rkt
+++ b/barrel/expander.rkt
@@ -4,10 +4,10 @@
 (require "core.rkt")
 (provide (all-from-out "core.rkt"))
 
-(define definitions (make-hash))
 (provide definitions)
+(define definitions (make-hash))
 
-(define-macro (barrel-module-begin PARSE-TREE) 
+(define-macro (barrel-module-begin PARSE-TREE)
   #'(#%module-begin
      PARSE-TREE))
 (provide (rename-out [barrel-module-begin #%module-begin]))
@@ -17,7 +17,7 @@
    (foldl (lambda (f prev) (f prev)) stack words))
 
 (define (apply-word words stack)
-  (apply-stack stack words))
+  (apply-stack stack (words)))
 
 (define-macro (words WORDS ...)
   #'(last (list WORDS ...)))
@@ -30,7 +30,7 @@
 (provide main)
 
 (define-macro (word WORDS ...)
-  #'(dict-set! definitions (first (list WORDS ...)) (rest (list WORDS ...))))
+  #'(block (dict-set! definitions (first (list WORDS ...)) (rest (list WORDS ...)))))
 (provide word)
 
 (define-macro (const CONST)
@@ -56,9 +56,9 @@
   [(id "λ") #'(begin
                 (displayln "revenge of the lambda")
                 (error 'lambda))]
-  [(id ID) #'(with-handlers ([exn:fail?
-                              (lambda (e) (begin
-                                            (displayln (format "unknown id: ~a" ID))
-                                            (error 'unknown-id)))])
-                ((curry apply-word) (dict-ref definitions ID)))])
+  [(id ID) #'((curry apply-word) (lambda ()
+											  (with-handlers ([exn:fail?
+																	  (lambda (e) (begin
+																						 (displayln (format "unknown id: ~a" ID))
+																						 (error 'unknown-id)))]) (dict-ref definitions ID))))])
 (provide id)

--- a/barrel/reader.rkt
+++ b/barrel/reader.rkt
@@ -1,6 +1,6 @@
 #lang br/quicklang
 (require "parser.rkt")
-;(require "expander.rkt")
+(require "expander.rkt")
 (require threading)
 (require racket/string)
 (require racket/dict)
@@ -25,7 +25,7 @@
                                                                                                   lexeme
                                                                                                   (string-trim "::")
                                                                                                   (string-trim)))
-                                                                                           ;(dict-set! definitions name empty)
+                                                                                           (dict-set! definitions name empty)
                                                                                            (token 'NAME name))]
        [(union (concatenation (union "-" "") (concatenation (:+ numeric) (union (concatenation "." (:+ numeric)) "")))) (token 'CONST (string->number lexeme))]
        [(concatenation "\"" (:+ (union alphabetic symbolic whitespace)) "\"") (token 'CONST (string-trim lexeme "\""))]

--- a/barrel/reader.rkt
+++ b/barrel/reader.rkt
@@ -25,7 +25,7 @@
                                                                                                   lexeme
                                                                                                   (string-trim "::")
                                                                                                   (string-trim)))
-                                                                                           (dict-set! definitions name empty)
+                                                                                           ;(dict-set! definitions name empty)
                                                                                            (token 'NAME name))]
        [(union (concatenation (union "-" "") (concatenation (:+ numeric) (union (concatenation "." (:+ numeric)) "")))) (token 'CONST (string->number lexeme))]
        [(concatenation "\"" (:+ (union alphabetic symbolic whitespace)) "\"") (token 'CONST (string-trim lexeme "\""))]

--- a/barrel/reader.rkt
+++ b/barrel/reader.rkt
@@ -25,7 +25,6 @@
                                                                                                   lexeme
                                                                                                   (string-trim "::")
                                                                                                   (string-trim)))
-                                                                                           ;(dict-set! definitions name empty)
                                                                                            (token 'NAME name))]
        [(union (concatenation (union "-" "") (concatenation (:+ numeric) (union (concatenation "." (:+ numeric)) "")))) (token 'CONST (string->number lexeme))]
        [(concatenation "\"" (:+ (union alphabetic symbolic whitespace)) "\"") (token 'CONST (string-trim lexeme "\""))]

--- a/barrel/util.rkt
+++ b/barrel/util.rkt
@@ -1,8 +1,0 @@
-#lang br
-(require syntax/parse/define)
-
-(define-simple-macro (string-define NAME EXPR)
-  #:with ID (format-id #'NAME "~a" (syntax-e #'NAME))
-  (define ID EXPR))
-(provide string-define)
-

--- a/tests/recursion.rkt
+++ b/tests/recursion.rkt
@@ -1,4 +1,5 @@
 #lang barrel
 
-forever :: "recursing" .n 
-main :: forever
+; forever :: "recursing" .n forever ;
+add-one :: 1 +
+main :: 1 add-one add-one .


### PR DESCRIPTION
This adds recursion, including mutual recursion, to Barrel. This works by deferring variable lookup to runtime. The main (pun intended) limitation is that the `main` function cannot be called recursively because it is handled separately to other functions. The fix for this would be have the `main` function be a normal function - which would have the side effect of simplifying the language significantly.